### PR TITLE
Add ENTRYPOINT to plugin builder to build packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# irods_auth_plugin_pam_interactive
+
+## How to build
+
+The following packages are required to build this project:
+ - irods-dev
+ - irods-runtime
+
+You will also need CMake of minimum version 3.12.0 and Clang of minimum version 13.0.0. These can be acquired through the following iRODS externals packages:
+ - irods-externals-cmake3.21.4-0
+ - irods-externals-clang13.0.0-0
+
+To build, run the following:
+```bash
+mkdir -p build && cd build
+cmake ..
+make package
+```
+
+## How to build with Docker
+
+You can also build packages by running the `plugin_builder` Docker Image. The container runs a script which follows the instructions above for building. The source code and build directory are provided to the container via volume mounts at run time so that the build artifacts and packages will be stored on the host machine.
+
+To get started, build the builder image, e.g.:
+```
+docker build -f plugin_builder.ubuntu20.Dockerfile -t pam-interactive-builder:ubuntu-20.04 .
+```
+
+Then, run the builder, e.g.:
+```
+docker run -it --rm \
+    -v /path/to/fork/of/irods_auth_plugin_pam_interactive:/src:ro \
+    -v /path/to/fork/of/irods_auth_plugin_pam_interactive/build:/bld \
+    pam-interactive-builder:ubuntu-20.04
+```

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,0 +1,13 @@
+#! /bin/bash -xe
+
+build_dir=/bld
+source_dir=/src
+cmake_path=/opt/irods-externals/cmake3.21.4-0/bin
+
+mkdir -p ${build_dir} && cd ${build_dir}
+
+PATH=${cmake_path}:$PATH
+
+cmake ${source_dir}
+
+make -j package

--- a/plugin_builder.ubuntu20.Dockerfile
+++ b/plugin_builder.ubuntu20.Dockerfile
@@ -39,3 +39,7 @@ RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - 
     apt-get update
 
 RUN apt install -y 'irods-externals*' irods-dev libpam-dev 
+
+COPY build_packages.sh /
+RUN chmod u+x /build_packages.sh
+ENTRYPOINT ["./build_packages.sh"]


### PR DESCRIPTION
This change adds a script to the plugin_builder Dockerfiles which runs CMake using a hard-coded iRODS externals path as well as make package. This could be improved by allowing for variable paths and passing options through to the cmake and make calls.

In order to use this, run the following, e.g.:

docker run -it --rm \
    -v /path/to/this/repo:/src:ro \
    -v /path/to/build/dir:/bld \
    pam-interactive-builder:ubuntu-20.04

This will result in build artifacts in the host machine in the directory at /path/to/build/dir. These can then be copied elsewhere to be installed/tested.

Added a README.md so we don't forget how to build this. :)