### PR TITLE
Fix building against 4.3.1ish and add option to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,14 @@ docker run -it --rm \
     -v /path/to/fork/of/irods_auth_plugin_pam_interactive/build:/bld \
     pam-interactive-builder:ubuntu-20.04
 ```
+
+The package builder image supports building with custom iRODS packages if the plugin is being built/tested with unreleased code. The `--irods-packages` option was created for this purpose and will install the locally built packages at the specified path, when used. The option must specify a directory inside the container which contains the required packages to build the plugin appropriate to the target platform. This can be accomplished through a read-only volume mount. The directory mountpoint is then used with the option and can be named whatever you want, as long as it matches the volume mount specification. Here is an example usage (target platform is ubuntu-20.04):
+```bash
+$ ls /path/to/built/packages
+irods-dev_4.3.0-1~focal_amd64.deb  irods-runtime_4.3.0-1~focal_amd64.deb  <...>
+$ docker run -it --rm \
+    -v /path/to/fork/of/irods_auth_plugin_pam_interactive:/src:ro \
+    -v /path/to/fork/of/irods_auth_plugin_pam_interactive/build:/bld \
+    -v /path/to/built/packages:/my_irods_packages:ro \
+    pam-interactive-builder:ubuntu-20.04 --irods-packages /my_irods_packages
+```

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,8 +1,37 @@
-#! /bin/bash -xe
+#! /bin/bash -e
+
+usage() {
+cat <<_EOF_
+Available options:
+
+    --irods-packages        Path to custom externals packages received via volume mount
+    -h, --help              This message
+_EOF_
+    exit
+}
+
+package_manager="apt-get"
+file_extension="deb"
 
 build_dir=/bld
 source_dir=/src
 cmake_path=/opt/irods-externals/cmake3.21.4-0/bin
+irods_packages_dir=
+
+while [ -n "$1" ] ; do
+    case "$1" in
+        --irods-packages)        shift; irods_packages_dir="$1";;
+        -h|--help)               usage;;
+    esac
+    shift
+done
+
+if [[ ! -z "${irods_packages_dir}" ]] ; then
+    apt-get update
+    dpkg -i "${irods_packages_dir}"/irods-dev*."${file_extension}"
+    dpkg -i "${irods_packages_dir}"/irods-runtime*."${file_extension}"
+    apt-get install -fy --allow-downgrades
+fi
 
 mkdir -p ${build_dir} && cd ${build_dir}
 

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -4,8 +4,8 @@ usage() {
 cat <<_EOF_
 Available options:
 
-    --irods-packages        Path to custom externals packages received via volume mount
-    -h, --help              This message
+    --irods-packages    Path to custom iRODS packages received via volume mount
+    -h, --help          This message
 _EOF_
     exit
 }

--- a/src/pam_interactive.cpp
+++ b/src/pam_interactive.cpp
@@ -503,7 +503,7 @@ namespace irods
     {
         const auto config_handle = irods::server_properties::instance().map();
         const auto& config_json = config_handle.get_json();
-        if (const auto& itr = config_json.find(jptr); std::end(config_json) != itr) {
+        if (const auto itr = config_json.find(jptr); std::end(config_json) != itr) {
             return itr->get<int>();
         }
 


### PR DESCRIPTION
Didn't touch the centos:7 builder because it doesn't have the `ENTRYPOINT` defined. We will eventually need to make sure this builds for all of our supported platforms for 4.3.1 (ubuntu:18.04, ubuntu:20.04, centos:7, EL8 et al)